### PR TITLE
テーマ登録者でないのに、テーマの編集が画面が表示されるバグを修正 #40

### DIFF
--- a/app/views/themes/show.html.erb
+++ b/app/views/themes/show.html.erb
@@ -64,6 +64,8 @@
 <hr/>
 
 <div class="actions pb-4">
-  <%= link_to t("helpers.links.edit"), edit_theme_path(@theme), class: "btn btn-outline-primary" %>
+  <% if @theme.owner?(current_user) %>
+    <%= link_to t("helpers.links.edit"), edit_theme_path(@theme), class: "btn btn-outline-primary" %>
+  <% end %>
   <%= link_to t("helpers.links.back"), themes_path, class: "btn btn-outline-primary" %>
 </div>


### PR DESCRIPTION
実際に押したらrootに遷移していた